### PR TITLE
Remove cut'n'paste leftover from GPT Chat app.

### DIFF
--- a/twitter/twitter/helpers.py
+++ b/twitter/twitter/helpers.py
@@ -25,7 +25,6 @@ def navbar(State):
                         )
                     ),
                     pc.menu_divider(),
-                    pc.link(pc.menu_item("About GPT"), href="https://openai.com/api/"),
                     pc.link(pc.menu_item("Sign Out"), on_click=State.logout),
                 ),
             ),


### PR DESCRIPTION
Noticed this left in the menu, maybe copied from the GPT Chat app?