### PR TITLE
Use REFLEX_DEP instead of REFLEX_VERSION

### DIFF
--- a/.github/workflows/app_harness.yml
+++ b/.github/workflows/app_harness.yml
@@ -1,7 +1,7 @@
 name: app-harness
 env:
   # TODO: switch to the official release
-  REFLEX_VERSION: '==0.4.0a4'
+  REFLEX_DEP: 'reflex==0.4.0a4'
   TELEMETRY_ENABLED: false
   APP_HARNESS_HEADLESS: 1
 on:
@@ -11,8 +11,8 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      reflex_version:
-        description: 'Reflex version'
+      reflex_dep:
+        description: 'Reflex dep (raw pip spec)'
 
 jobs:
   list-examples-with-tests:
@@ -51,6 +51,6 @@ jobs:
           python -m venv venv
           source venv/bin/activate
 
-          pip install 'reflex${{ github.event.inputs.reflex_version || env.REFLEX_VERSION }}' -r requirements.txt -r requirements-dev.txt
+          pip install '${{ github.event.inputs.reflex_dep || env.REFLEX_DEP }}' -r requirements.txt -r requirements-dev.txt
           reflex init
           pytest tests -vv

--- a/.github/workflows/check_export.yml
+++ b/.github/workflows/check_export.yml
@@ -1,7 +1,7 @@
 name: check-export
 env:
   # TODO: switch to the official release
-  REFLEX_VERSION: '==0.4.0a4'
+  REFLEX_DEP: 'reflex==0.4.0a4'
   TELEMETRY_ENABLED: false
 on:
   push:
@@ -10,8 +10,8 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      reflex_version:
-        description: 'Reflex version'
+      reflex_dep:
+        description: 'Reflex dep (raw pip spec)'
 
 jobs:
   list-examples:
@@ -60,7 +60,7 @@ jobs:
           python -m venv venv
           source venv/bin/activate
 
-          pip install 'reflex${{ github.event.inputs.reflex_version || env.REFLEX_VERSION }}' -r requirements.txt
+          pip install '${{ github.event.inputs.reflex_dep || env.REFLEX_DEP }}' -r requirements.txt
           export OPENAI_API_KEY="dummy"
           reflex init
           reflex export


### PR DESCRIPTION
Allow specification of reflex as a full pip URL so CI can test with unreleased versions of reflex.

This aligns with how the reflex dependency is specified in reflex-dev/reflex-web repo.