### PR TITLE
Run CI with the latest Reflex

### DIFF
--- a/.github/workflows/app_harness.yml
+++ b/.github/workflows/app_harness.yml
@@ -1,6 +1,6 @@
 name: app-harness
 env:
-  REFLEX_DEP: 'reflex==0.4.3'
+  REFLEX_DEP: 'reflex'
   TELEMETRY_ENABLED: false
   APP_HARNESS_HEADLESS: 1
 on:

--- a/.github/workflows/check_export.yml
+++ b/.github/workflows/check_export.yml
@@ -1,6 +1,6 @@
 name: check-export
 env:
-  REFLEX_DEP: 'reflex==0.4.3'
+  REFLEX_DEP: 'reflex'
   TELEMETRY_ENABLED: false
 on:
   push:


### PR DESCRIPTION
This will help us catch regressions in the reflex-examples sooner, even if it means a broken CI sometimes on an unrelated change.