### PR TITLE
Use py3.11 compatible f-strings

### DIFF
--- a/customer_data_app/customer_data_app/backend/backend.py
+++ b/customer_data_app/customer_data_app/backend/backend.py
@@ -145,7 +145,7 @@ class State(rx.State):
             session.add(Customer(**self.current_user))
             session.commit()
         self.load_entries()
-        return rx._x.toast.info(f"User {self.current_user["name"]} has been added.", variant="outline", position="bottom-right")
+        return rx.toast.info(f"User {self.current_user['name']} has been added.", variant="outline", position="bottom-right")
     
 
     def update_customer_to_db(self, form_data: dict):
@@ -160,7 +160,7 @@ class State(rx.State):
             session.add(customer)
             session.commit()
         self.load_entries()
-        return rx._x.toast.info(f"User {self.current_user["name"]} has been modified.", variant="outline", position="bottom-right")
+        return rx.toast.info(f"User {self.current_user['name']} has been modified.", variant="outline", position="bottom-right")
 
 
     def delete_customer(self, id: int):
@@ -170,7 +170,7 @@ class State(rx.State):
             session.delete(customer)
             session.commit()
         self.load_entries()
-        return rx._x.toast.info(f"User {customer.name} has been deleted.", variant="outline", position="bottom-right")
+        return rx.toast.info(f"User {customer.name} has been deleted.", variant="outline", position="bottom-right")
     
     
     @rx.var


### PR DESCRIPTION
Remove _x. prefix from toast events.

Fix #250