### PR TITLE
Store the users hashed password using bcrypt instead of the plaintext…

### DIFF
--- a/twitter/requirements.txt
+++ b/twitter/requirements.txt
@@ -1,1 +1,2 @@
-reflex>=0.4.0
+bcrypt>=4.2.0
+reflex>=0.5.10

--- a/twitter/twitter/db_model.py
+++ b/twitter/twitter/db_model.py
@@ -1,6 +1,5 @@
-from sqlmodel import Field
-
 import reflex as rx
+from sqlmodel import Field
 
 
 class Follows(rx.Model, table=True):
@@ -17,7 +16,7 @@ class User(rx.Model, table=True):
     """A table of Users."""
 
     username: str
-    password: str
+    password: bytes
 
 
 class Tweet(rx.Model, table=True):


### PR DESCRIPTION
This updates the twitter example to hash the users password using bcrypt and store that instead of storing it in plaintext. Since https://reflex.dev/docs/authentication/authentication-overview/ points to this example for Local Auth I figured it was a good idea to use best practices like not storing passwords in plain text.